### PR TITLE
Explicit length formatting

### DIFF
--- a/src/bintools/cmpvec.cc
+++ b/src/bintools/cmpvec.cc
@@ -64,7 +64,7 @@ int main (int argc, char *argv[])
 
     if (!ifs1 || !ifs2) {
         char cbuf[256];
-	sprintf (cbuf, "Could not open file: %s", vecname[!ifs1 ? 0 : 1]);
+	snprintf (cbuf, sizeof(cbuf), "Could not open file: %s", vecname[!ifs1 ? 0 : 1]);
 	print_error_and_exit(cbuf, 3);
     }
 
@@ -85,7 +85,7 @@ int main (int argc, char *argv[])
 	    if (!vec_diff) vec_diff = (diff != 0);
 	    if (diff > maxerr) {
 		char cbuf[256];
-		sprintf (cbuf, "Vectors differ in element %d", i+1);
+		snprintf (cbuf, sizeof(cbuf), "Vectors differ in element %d", i+1);
 		print_error_and_exit (cbuf, 1);
 	    }
 	}
@@ -106,7 +106,7 @@ int main (int argc, char *argv[])
 	    if (!vec_diff) vec_diff = (diff != 0);
 	    if (diff > maxerr) {
 		char cbuf[256];
-		sprintf (cbuf, "Vectors differ in element %d", i+1);
+		snprintf (cbuf, sizeof(cbuf), "Vectors differ in element %d", i+1);
 		print_error_and_exit (cbuf, 1);
 	    }
 	}

--- a/src/libfdot/MLEMSolver.cc
+++ b/src/libfdot/MLEMSolver.cc
@@ -76,7 +76,7 @@ int MLEMSolver::Solve(const RVector & data,
     {
 	fwdOperator(result, y);
 	char fname[100];
-	sprintf(fname, "fwdOp_on_result%d.dat", i);
+	snprintf(fname, sizeof(fname), "fwdOp_on_result%d.dat", i);
 	WriteBinaryData(y, fname);
 	for (int j=0; j<y.Dim(); ++j)
 	{
@@ -187,7 +187,7 @@ void MLEMSolver::adjOperator(RVector & b)
 	tmpImg.Copy(b, 0, i*nImagePts, nImagePts);	
 	projectors[i]->projectImageToField(tmpImg, tmpFld);
 	char fname[100];
-	sprintf(fname, "tmpFld%d.dat", i);
+	snprintf(fname, sizeof(fname), "tmpFld%d.dat", i);
 	WriteBinaryData(tmpFld, fname);
 	FEMSolver.CalcField (/*FEMMesh,*/ tmpFld, adjPhi_f);
 	raster->Map_MeshToGrid(adjPhi_f, gAdjPhi_f);

--- a/src/libfdot/muaSolver.cc
+++ b/src/libfdot/muaSolver.cc
@@ -115,11 +115,11 @@ int MuaSolver::Solve(const RVector & data,
 	IVector imgDim = projectors[0]->getImageDim();
 	for (int j=0; j<nQ; ++j)
 	{
-	    sprintf(fname, "solnexcit_data_iter%d_img%d.pgm", i, j);
+	    snprintf(fname, sizeof(fname), "solnexcit_data_iter%d_img%d.pgm", i, j);
 	    im.Copy(Fx, 0, j*nImagePts, nImagePts);
 	    WritePGM(im, imgDim, fname);
 
-	    sprintf(fname, "excit_err_data_iter%d_img%d.pgm", i, j);
+	    snprintf(fname, sizeof(fname), "excit_err_data_iter%d_img%d.pgm", i, j);
 	    im.Copy(data-Fx, 0, j*nImagePts, nImagePts);
 	    WritePGM(im, imgDim, fname);
 	}
@@ -134,7 +134,7 @@ int MuaSolver::Solve(const RVector & data,
 	    im.Copy(gResult, 0, slice*gDim[0]*gDim[1], gDim[0]*gDim[1]);
 	    append(soln, im);
 	}
-	sprintf(fname, "mua_soln_iter%d_slices.dat", i);
+	snprintf(fname, sizeof(fname), "mua_soln_iter%d_slices.dat", i);
 	WriteBinaryData(soln, fname);
     }
 

--- a/src/libfdot/util.cc
+++ b/src/libfdot/util.cc
@@ -756,7 +756,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -767,7 +767,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf) - strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;

--- a/src/libmath/error.cc
+++ b/src/libmath/error.cc
@@ -45,7 +45,7 @@ void SetErrorhandler (void (*ErrorFunc)(char*))
 MATHLIB void Error (const char *name, const char *file, int line)
 {
     char cbuf[500];
-    sprintf (cbuf, "**** Error in module mathlib ****\nIn %s\nFile %s line %d\n"
+    snprintf (cbuf, sizeof(cbuf), "**** Error in module mathlib ****\nIn %s\nFile %s line %d\n"
 	, name, file, line);
     Errorhandler (cbuf);
 }
@@ -67,7 +67,7 @@ MATHLIB void Error (const char *name, const char *file, int line, const char *ms
 MATHLIB void Error_Undef (const char *name, const char *file, int line)
 {
     char cbuf[500];
-    sprintf (cbuf, "#########################\nERROR IN LIBFE3:\nFunction not implemented:\n%s\n%s, %d\n#########################\n",
+    snprintf (cbuf, sizeof(cbuf), "#########################\nERROR IN LIBFE3:\nFunction not implemented:\n%s\n%s, %d\n#########################\n",
 	     name, file, line);
     Errorhandler (cbuf);
 }
@@ -169,7 +169,7 @@ void SetVersion (const char *vstr)
 
 const char *Version (const char *type, const char *date)
 {
-    sprintf (fullversionstr, "TOAST-- distribution [%s] - Build %s\n", type, date);
+    snprintf (fullversionstr, sizeof(fullversionstr), "TOAST-- distribution [%s] - Build %s\n", type, date);
 #ifdef TOAST_THREAD
     strcat (fullversionstr, "Running parallel (pthreads) version\n");
 #endif

--- a/src/libstoast/pparse.cc
+++ b/src/libstoast/pparse.cc
@@ -81,7 +81,7 @@ bool ParamParser::GetString (const char *cat, char *str)
 void ParamParser::PutString (const char *cat, const char *str)
 {
     char cbuf[256];
-    sprintf (cbuf, "%s = %s", cat, str);
+    snprintf (cbuf, sizeof(cbuf), "%s = %s", cat, str);
     Lineout (cbuf);
 }
 
@@ -95,7 +95,7 @@ bool ParamParser::GetReal (const char *cat, double &val)
 void ParamParser::PutReal (const char *cat, double val)
 {
     char cbuf[256];
-    sprintf (cbuf, "%s = %g", cat, val);
+    snprintf (cbuf, sizeof(cbuf), "%s = %g", cat, val);
     Lineout (cbuf);
 }
 
@@ -109,7 +109,7 @@ bool ParamParser::GetInt (const char *cat, int &val)
 void ParamParser::PutInt (const char *cat, int val)
 {
     char cbuf[256];
-    sprintf (cbuf, "%s = %d", cat, val);
+    snprintf (cbuf, sizeof(cbuf), "%s = %d", cat, val);
     Lineout (cbuf);
 }
 
@@ -125,6 +125,6 @@ bool ParamParser::GetBool(const char *cat, bool &val)
 void ParamParser::PutBool (const char *cat, bool val)
 {
     char cbuf[256];
-    sprintf (cbuf, "%s = %s", cat, val ? "TRUE":"FALSE");
+    snprintf (cbuf, sizeof(cbuf), "%s = %s", cat, val ? "TRUE":"FALSE");
     Lineout (cbuf);
 }

--- a/src/matlab/matlabtoast.cc
+++ b/src/matlab/matlabtoast.cc
@@ -12,9 +12,9 @@ void AssertArg (bool cond, const char *func, int argno, const char *errmsg)
     if (!cond) {
 	char str[1024];
 	if (argno)
-	    sprintf (str, "%s: argument %d: %s.", func, argno, errmsg);
+	    snprintf (str, sizeof(str), "%s: argument %d: %s.", func, argno, errmsg);
 	else
-	    sprintf (str, "%s: %s.", func, errmsg);
+	    snprintf (str, sizeof(str), "%s: %s.", func, errmsg);
 	mexErrMsgTxt (str);
     }
 }

--- a/src/matlab/mtMesh.cc
+++ b/src/matlab/mtMesh.cc
@@ -551,7 +551,7 @@ void MatlabToast::WriteQM (int nlhs, mxArray *plhs[], int nrhs,
 
 	if (nq != lnk.nRows() || nm != lnk.nCols()) {
 	    char cbuf[256];
-	    sprintf (cbuf, "Invalid dimension (was: %d x %d, expected %d x %d)",
+	    snprintf (cbuf, sizeof(cbuf),"Invalid dimension (was: %d x %d, expected %d x %d)",
 		     lnk.nCols(), lnk.nRows(), nm, nq);
 	    ASSERTARG(0, 4, cbuf);
 	}

--- a/src/matlab/mtProjector.cc
+++ b/src/matlab/mtProjector.cc
@@ -81,7 +81,7 @@ void MatlabFDOT::MakeProjectorList (int nlhs, mxArray *plhs[],
 	ctp = CAMTYPE_ORTHO;
     } else {
 	char cbuf[256];
-	sprintf (cbuf, "Camera type %s not supported", str);
+	snprintf (cbuf, sizeof(cbuf), "Camera type %s not supported", str);
 	mexErrMsgTxt (cbuf);
     }
 

--- a/src/matlab/mtQMvec.cc
+++ b/src/matlab/mtQMvec.cc
@@ -92,7 +92,7 @@ void MatlabToast::Mvec (int nlhs, mxArray *plhs[], int nrhs,
 		int len = (int) (mxGetM(prhs[3])*mxGetN(prhs[3]));
 		if ((len != 1 && len != n) || !mxIsDouble(prhs[3])) {
 			char cbuf[256];
-			sprintf (cbuf, "Mvec: parameter 3: expected double scalar or double vector of length %d", n);
+			snprintf (cbuf, sizeof(cbuf), "Mvec: parameter 3: expected double scalar or double vector of length %d", n);
 			mexErrMsgTxt (cbuf);
 		}
 		if (len == 1) {

--- a/src/matlab/util.cc
+++ b/src/matlab/util.cc
@@ -152,7 +152,7 @@ void WritePPMArray (const RVector *img, const IVector &gdim, int nimg,
 	break;
     }
     for (int i = 0; i < nimg; i++) {
-	sprintf (fname, "%s_%03d.ppm", rootname, i);
+	snprintf (fname, sizeof(fname), "%s_%03d.ppm", rootname, i);
 	WritePPM (img[i], gdim, scalemin, scalemax, fname);
     }
 }

--- a/src/supertoast/fwdfem.cc
+++ b/src/supertoast/fwdfem.cc
@@ -687,7 +687,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -698,7 +698,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;

--- a/src/supertoast/fwdfem_cw.cc
+++ b/src/supertoast/fwdfem_cw.cc
@@ -657,7 +657,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -668,7 +668,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;

--- a/src/supertoast/fwdfem_tpsf.cc
+++ b/src/supertoast/fwdfem_tpsf.cc
@@ -666,7 +666,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -677,7 +677,7 @@ void SelectInitialParams (ParamParser &pp, const Mesh &mesh, Solution &msol)
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;

--- a/src/supertoast/solverlm.cc
+++ b/src/supertoast/solverlm.cc
@@ -1406,11 +1406,11 @@ void SolverLM::Solve (CFwdSolver &FWS, const Raster &raster,
 		RVector vg(glen);
 		raster.Map_SolToGrid (tmp1, vg);
 		if (!count) ImageScale (vg, muamin, muamax);
-		sprintf (cbuf, "images/update_mua_%03d.ppm", count);
+		snprintf (cbuf, sizeof(cbuf), "images/update_mua_%03d.ppm", count);
 		WritePPM (vg, raster.GDim(), &muamin, &muamax, cbuf);
 		raster.Map_SolToGrid (tmp2, vg);
 		if (!count) ImageScale (vg, kappamin, kappamax);
-		sprintf (cbuf, "images/update_kappa_%03d.ppm", count);
+		snprintf (cbuf, sizeof(cbuf), "images/update_kappa_%03d.ppm", count);
 		WritePPM (vg, raster.GDim(), &kappamin, &kappamax, cbuf);
 		count++;
 	    }

--- a/src/supertoast/supertoast.cc
+++ b/src/supertoast/supertoast.cc
@@ -528,13 +528,13 @@ void OutputProgramInfo ()
     pp.Lineout ("| diffusion equation from frequency-domain data   |");
     pp.Lineout ("+-------------------------------------------------+");
     pp.Lineout (VERSION_STRING);
-    sprintf (cbuf, "Executed %s", ctime(&tme));
+    snprintf (cbuf, sizeof(cbuf), "Executed %s", ctime(&tme));
     if ((host = getenv("HOST")))
-        sprintf (cbuf+strlen(cbuf), "on host %s ", host);
-    sprintf (cbuf+strlen(cbuf), "(PID %d)", getpid());
+        snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), "on host %s ", host);
+    snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), "(PID %d)", getpid());
     pp.Lineout (cbuf);
     if (getcwd (cwd, 250)) {
-        sprintf (cbuf, "CWD: %s", cwd);
+        snprintf (cbuf, sizeof(cbuf), "CWD: %s", cwd);
 	pp.Lineout (cbuf);
     }
     pp.Lineout ("===================================================");
@@ -866,7 +866,7 @@ void SelectInitialParams (const Mesh &mesh, Solution &msol)
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -877,7 +877,7 @@ void SelectInitialParams (const Mesh &mesh, Solution &msol)
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;
@@ -990,14 +990,14 @@ void SelectBasis (IVector &gdim, IVector &bdim)
 
     // write back
     if (dim > 2) {
-        sprintf (cbuf, "%d %d %d", gdim[0], gdim[1], gdim[2]);
+        snprintf (cbuf, sizeof(cbuf), "%d %d %d", gdim[0], gdim[1], gdim[2]);
 	pp.PutString ("GRID", cbuf);
-	sprintf (cbuf, "%d %d %d", bdim[0], bdim[1], bdim[2]);
+	snprintf (cbuf, sizeof(cbuf), "%d %d %d", bdim[0], bdim[1], bdim[2]);
 	pp.PutString ("BASIS", cbuf);
     } else {
-        sprintf (cbuf, "%d %d", gdim[0], gdim[1]);
+        snprintf (cbuf, sizeof(cbuf), "%d %d", gdim[0], gdim[1]);
 	pp.PutString ("GRID", cbuf);
-	sprintf (cbuf, "%d %d", bdim[0], bdim[1]);
+	snprintf (cbuf, sizeof(cbuf), "%d %d", bdim[0], bdim[1]);
 	pp.PutString ("BASIS", cbuf);
     }
 }

--- a/src/supertoast/supertoast_cw_mw.cc
+++ b/src/supertoast/supertoast_cw_mw.cc
@@ -552,13 +552,13 @@ void OutputProgramInfo ()
     pp.Lineout ("| diffusion equation from frequency-domain data   |");
     pp.Lineout ("+-------------------------------------------------+");
     pp.Lineout (VERSION_STRING);
-    sprintf (cbuf, "Executed %s", ctime(&tme));
+    snprintf (cbuf, sizeof(cbuf), "Executed %s", ctime(&tme));
     if ((host = getenv("HOST")))
-        sprintf (cbuf+strlen(cbuf), "on host %s ", host);
-    sprintf (cbuf+strlen(cbuf), "(PID %d)", getpid());
+        snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), "on host %s ", host);
+    snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), "(PID %d)", getpid());
     pp.Lineout (cbuf);
     if (getcwd (cwd, 250)) {
-        sprintf (cbuf, "CWD: %s", cwd);
+        snprintf (cbuf, sizeof(cbuf), "CWD: %s", cwd);
 	pp.Lineout (cbuf);
     }
     pp.Lineout ("===================================================");
@@ -748,18 +748,18 @@ void SelectInitialParams (const Mesh &mesh, MWsolution &msol,
       char reconstr[256];
 
       if (p < msol.nmuaChromo) {
-	  sprintf (resetstr,"CHROMOPHORE_%d",p+1);
-	  sprintf (reconstr, "RECON_CHROMOPHORE_%d",p+1);
+	  snprintf (resetstr, sizeof(resetstr),"CHROMOPHORE_%d",p+1);
+	  snprintf (reconstr, sizeof(reconstr), "RECON_CHROMOPHORE_%d",p+1);
       } else if (p == msol.nmuaChromo) {
-	  sprintf (resetstr,"SCATTERING_PREFACTOR_A");
-	  sprintf (reconstr, "RECON_SCATTERING_PREFACTOR_A");
+	  snprintf (resetstr, sizeof(resetstr),"SCATTERING_PREFACTOR_A");
+	  snprintf (reconstr, sizeof(reconstr), "RECON_SCATTERING_PREFACTOR_A");
       } else if (p == msol.nmuaChromo+1) {
-	  sprintf (resetstr,"SCATTERING_POWER_B");
-	  sprintf (reconstr, "RECON_SCATTERING_POWER_B");
+	  snprintf (resetstr, sizeof(resetstr),"SCATTERING_POWER_B");
+	  snprintf (reconstr, sizeof(reconstr), "RECON_SCATTERING_POWER_B");
       } else if (p == msol.nmuaChromo+2) {
-	  sprintf (resetstr,"RESET_N");
+	  snprintf (resetstr, sizeof(resetstr),"RESET_N");
       } else {
-	  sprintf (resetstr, "BACKGROUND_MUA_%d",
+	  snprintf (resetstr, sizeof(resetstr), "BACKGROUND_MUA_%d",
 		   (int)wlength[p-msol.nmuaChromo-3]);
       }
 
@@ -803,7 +803,7 @@ void SelectInitialParams (const Mesh &mesh, MWsolution &msol,
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -814,7 +814,7 @@ void SelectInitialParams (const Mesh &mesh, MWsolution &msol,
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;
@@ -871,7 +871,7 @@ void SelectInitialReferenceParams (const Mesh &mesh, Solution &msol,
     const ParameterType prmtp[3] = {PRM_MUA, PRM_MUS, PRM_N};
     for (p = 0; p < 3; p++) {
         char resetstr[256];
-	sprintf (resetstr,"%s_%d", rootstr[p], whichWavel);
+	snprintf (resetstr, sizeof(resetstr),"%s_%d", rootstr[p], whichWavel);
 
 	param[p].New(mesh.nlen());
 	if (pp.GetString (resetstr, cbuf)) {
@@ -914,7 +914,7 @@ void SelectInitialReferenceParams (const Mesh &mesh, Solution &msol,
 		cout << "\nGlobal value:\n>> ";
 		cin >> prm;
 		param[p] = prm;
-		sprintf (cbuf, "HOMOG %f", prm);
+		snprintf (cbuf, sizeof(cbuf), "HOMOG %f", prm);
 		break;
 	    case 2:
 		nreg = ScanRegions (mesh, nregnode);
@@ -925,7 +925,7 @@ void SelectInitialReferenceParams (const Mesh &mesh, Solution &msol,
 			cout << "Value for region " << i << " (" << nregnode[i]
 			     << " nodes):\n>> ";
 			cin >> prm;
-			sprintf (cbuf+strlen(cbuf), " %f", prm);
+			snprintf (cbuf+strlen(cbuf), sizeof(cbuf)-strlen(cbuf), " %f", prm);
 			for (j = 0; j < mesh.nlen(); j++)
 			    if (mesh.nlist[j].Region() == i)
 				param[p][j] = prm;
@@ -967,7 +967,7 @@ void SelectData (DataScale dscale, int nqm, int nlambda, const RVector &wlength,
 
 	switch (dscale) {
 	case DATA_LIN:
-  	    sprintf (tag, "DATA_REAL_WAVEL_%0.0f", wlength[i]);
+  	    snprintf (tag, sizeof(tag), "DATA_REAL_WAVEL_%0.0f", wlength[i]);
 	    if (!pp.GetString (tag, cbuf)) {
 	        cout << "\nData file for " << tag << ":\n>> ";
 		cin >> cbuf;
@@ -976,7 +976,7 @@ void SelectData (DataScale dscale, int nqm, int nlambda, const RVector &wlength,
 	    ReadDataFile (cbuf, adata);
 	    break;
 	case DATA_LOG:
-  	    sprintf (tag, "DATA_MOD_WAVEL_%0.0f", wlength[i]);
+  	    snprintf (tag, sizeof(tag), "DATA_MOD_WAVEL_%0.0f", wlength[i]);
 	    if (!pp.GetString (tag, cbuf)) {
 	        cout << "\nData file for " << tag << ":\n>> ";
 		cin >> cbuf;
@@ -1004,7 +1004,7 @@ void SelectRefdata (DataScale dscale, int nqm, int nlambda,
 
 	switch (dscale) {
 	case DATA_LIN:
-  	    sprintf (tag, "REFDATA_REAL_WAVEL_%0.0f", wlength[i]);
+  	    snprintf (tag, sizeof(tag), "REFDATA_REAL_WAVEL_%0.0f", wlength[i]);
 	    if (!pp.GetString (tag, cbuf)) {
 	        cout << "\nReference data file for " << tag << ":\n>> ";
 		cin >> cbuf;
@@ -1013,7 +1013,7 @@ void SelectRefdata (DataScale dscale, int nqm, int nlambda,
 	    ReadDataFile (cbuf, adata);
 	    break;
 	case DATA_LOG:
-  	    sprintf (tag, "REFDATA_MOD_WAVEL_%0.0f", wlength[i]);
+  	    snprintf (tag, sizeof(tag), "REFDATA_MOD_WAVEL_%0.0f", wlength[i]);
 	    if (!pp.GetString (tag, cbuf)) {
 	        cout << "\nReference data file for " << tag << ":\n>> ";
 		cin >> cbuf;
@@ -1068,14 +1068,14 @@ void SelectBasis (IVector &gdim, IVector &bdim)
 
     // write back
     if (dim > 2) {
-        sprintf (cbuf, "%d %d %d", gdim[0], gdim[1], gdim[2]);
+        snprintf (cbuf, sizeof(cbuf), "%d %d %d", gdim[0], gdim[1], gdim[2]);
 	pp.PutString ("GRID", cbuf);
-	sprintf (cbuf, "%d %d %d", bdim[0], bdim[1], bdim[2]);
+	snprintf (cbuf, sizeof(cbuf), "%d %d %d", bdim[0], bdim[1], bdim[2]);
 	pp.PutString ("BASIS", cbuf);
     } else {
-        sprintf (cbuf, "%d %d", gdim[0], gdim[1]);
+        snprintf (cbuf, sizeof(cbuf), "%d %d", gdim[0], gdim[1]);
 	pp.PutString ("GRID", cbuf);
-	sprintf (cbuf, "%d %d", bdim[0], bdim[1]);
+	snprintf (cbuf, sizeof(cbuf), "%d %d", bdim[0], bdim[1]);
 	pp.PutString ("BASIS", cbuf);
     }
 }

--- a/src/supertoast/supertoast_util.cc
+++ b/src/supertoast/supertoast_util.cc
@@ -31,7 +31,7 @@ void WriteJacobian (const RMatrix *J, const Raster &raster,
     if (dim != 2) { // for now, just dump the whole thing
 	for (i = 0; i < J->nRows(); i++) {
 	    char cbuf[256];
-	    sprintf (cbuf, "pmdf_%03d.dat", i);
+	    snprintf (cbuf, sizeof(cbuf), "pmdf_%03d.dat", i);
 	    ofstream ofs (cbuf);
 	    ofs << J->Row(i) << endl;
 	}

--- a/src/supertoast/util.cc
+++ b/src/supertoast/util.cc
@@ -204,7 +204,7 @@ void WritePPMArray (const RVector *img, const IVector &gdim, int nimg,
 	break;
     }
     for (int i = 0; i < nimg; i++) {
-	sprintf (fname, "%s_%03d.ppm", rootname, i);
+	snprintf (fname, sizeof(fname), "%s_%03d.ppm", rootname, i);
 	WritePPM (img[i], gdim, scalemin, scalemax, fname);
     }
 }


### PR DESCRIPTION
Quieten MacOS clang builds (and improve safety) by refactoring all xprintf calls for xnprintf variants