### PR TITLE
Set relative rpath on MacOS

### DIFF
--- a/.github/workflows/build_mex.yml
+++ b/.github/workflows/build_mex.yml
@@ -22,7 +22,7 @@ jobs:
         if: matrix.os == 'macos-14'
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024a
+          release: R2023b
 
       - name: Set up MATLAB (R2022a)
         if: matrix.os != 'macos-14'
@@ -48,6 +48,14 @@ jobs:
           cd build
           cmake ../
           cmake --build . --target install --config Release
+
+      # Fix the RPATH on MacOS (without this, the rpath is set to the absolute directory of the runners and
+      # libraries such as libMatlabEngine.dylib cannot be referenced
+      - name: Fix RPATH
+        if: matrix.os == 'macos-14' || matrix.os == 'macos-13'
+        run: |
+          MEX_FILE=$(ls dist/matlab/toast/*.mex*)
+          install_name_tool -add_rpath @exectuable_path/../../extern/bin/maca64 ${MEX_FILE}   
 
       # Code sign and archive on MacOS
       - name: Code sign, archive and notarize


### PR DESCRIPTION
When built on a runner our MEX ends up with an absolute rpath to a MATLAB lib directory which does not exist on the users machine. This adds a relative (`@executable_path`) rpath to the library to satisfy the loader.