### PR TITLE
Enforce build against NumPy2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,6 +10,11 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    # Force buil-time (not run-time) Python version
+    env:
+      CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
+      
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-13, macos-14]

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     url = 'https://github.com/samuelpowell/toastmm',
     setup_requires=['wheel'],
     install_requires=["numpy", "scipy"],
-    python_requires='>=3.9',
+    python_requires='>=3.6',
     extras_require={  
         "demo": ["matplotlib"]
     },


### PR DESCRIPTION
 - Continue to target the NumPy 1.7 API and Limited API
 - Build against NumPy 2 for compatibility

`cibuildwheel` picks the python version from the setuptools script (as it is not present in the project.toml), but we don't wish to enforce this for runtime, just build time, so that we can build against NP2.